### PR TITLE
Refactor email module for hexagonal architecture

### DIFF
--- a/internal/email/adapter/memory/repository.go
+++ b/internal/email/adapter/memory/repository.go
@@ -1,0 +1,160 @@
+package memory
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/example/iboz/internal/email"
+)
+
+var _ email.Repository = (*Repository)(nil)
+
+// Repository provides an in-memory implementation of the email.Repository port.
+type Repository struct {
+	mu       sync.RWMutex
+	config   *email.ProviderConfig
+	auth     *email.AuthRecord
+	messages []email.EmailMessage
+	lastSync time.Time
+}
+
+// NewRepository builds a new in-memory repository instance.
+func NewRepository() *Repository {
+	return &Repository{}
+}
+
+// SaveConfig stores the provider configuration.
+func (r *Repository) SaveConfig(ctx context.Context, cfg email.ProviderConfig) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	clone := cfg
+	clone.LabelFilters = append([]string(nil), cfg.LabelFilters...)
+
+	r.mu.Lock()
+	r.config = &clone
+	r.mu.Unlock()
+
+	return nil
+}
+
+// GetConfig returns the stored provider configuration if present.
+func (r *Repository) GetConfig(ctx context.Context) (*email.ProviderConfig, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	if r.config == nil {
+		return nil, nil
+	}
+
+	clone := *r.config
+	clone.LabelFilters = append([]string(nil), r.config.LabelFilters...)
+	return &clone, nil
+}
+
+// ClearAuth removes any stored authentication metadata.
+func (r *Repository) ClearAuth(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	r.mu.Lock()
+	r.auth = nil
+	r.mu.Unlock()
+	return nil
+}
+
+// SaveAuth persists the authentication record.
+func (r *Repository) SaveAuth(ctx context.Context, record email.AuthRecord) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	clone := record
+	clone.State.UpdatedAt = record.State.UpdatedAt
+
+	r.mu.Lock()
+	r.auth = &clone
+	r.mu.Unlock()
+	return nil
+}
+
+// GetAuth retrieves the stored authentication record if present.
+func (r *Repository) GetAuth(ctx context.Context) (*email.AuthRecord, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	if r.auth == nil {
+		return nil, nil
+	}
+
+	clone := *r.auth
+	clone.State = r.auth.State
+	return &clone, nil
+}
+
+// ClearMessages removes cached messages and last sync metadata.
+func (r *Repository) ClearMessages(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	r.mu.Lock()
+	r.messages = nil
+	r.lastSync = time.Time{}
+	r.mu.Unlock()
+	return nil
+}
+
+// SaveMessages replaces the cached messages and updates the last sync timestamp.
+func (r *Repository) SaveMessages(ctx context.Context, messages []email.EmailMessage, syncedAt time.Time) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	cloned := cloneMessages(messages)
+
+	r.mu.Lock()
+	r.messages = cloned
+	r.lastSync = syncedAt
+	r.mu.Unlock()
+	return nil
+}
+
+// GetMessages returns the cached messages and associated last sync timestamp.
+func (r *Repository) GetMessages(ctx context.Context) ([]email.EmailMessage, time.Time, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, time.Time{}, err
+	}
+
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	if len(r.messages) == 0 {
+		return nil, r.lastSync, nil
+	}
+
+	return cloneMessages(r.messages), r.lastSync, nil
+}
+
+func cloneMessages(messages []email.EmailMessage) []email.EmailMessage {
+	if len(messages) == 0 {
+		return nil
+	}
+	cloned := make([]email.EmailMessage, len(messages))
+	for i, msg := range messages {
+		cloned[i] = msg
+		cloned[i].Labels = append([]string(nil), msg.Labels...)
+	}
+	return cloned
+}

--- a/internal/email/adapter/synthetic/generator.go
+++ b/internal/email/adapter/synthetic/generator.go
@@ -1,0 +1,61 @@
+package synthetic
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/example/iboz/internal/email"
+)
+
+var _ email.MessageGenerator = (*Generator)(nil)
+
+// Generator produces deterministic sample messages for use in tests and demos.
+type Generator struct{}
+
+// NewGenerator constructs a new synthetic message generator.
+func NewGenerator() *Generator {
+	return &Generator{}
+}
+
+// Generate returns a deterministic set of email messages for the supplied configuration.
+func (g *Generator) Generate(ctx context.Context, cfg email.ProviderConfig, auth email.AuthState, now time.Time) ([]email.EmailMessage, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	baseLabels := append([]string{"INBOX"}, cfg.LabelFilters...)
+
+	summary := email.EmailMessage{
+		ID:         "msg-schedule",
+		Subject:    fmt.Sprintf("%s focus queue summary", strings.Title(cfg.DisplayName)),
+		Sender:     fmt.Sprintf("notifications@%s", cfg.Provider),
+		ReceivedAt: now.Add(-45 * time.Minute),
+		Snippet:    fmt.Sprintf("Automation insights for %s. 3 urgent items need review.", cfg.DisplayName),
+		Labels:     append([]string(nil), baseLabels...),
+		Importance: "high",
+	}
+
+	escalated := email.EmailMessage{
+		ID:         "msg-escalation",
+		Subject:    "Escalation: Contract signature pending",
+		Sender:     "legal-ops@example.com",
+		ReceivedAt: now.Add(-2 * time.Hour),
+		Snippet:    fmt.Sprintf("Hi %s, procurement is awaiting countersignature from vendor.", auth.Username),
+		Labels:     append([]string{"Escalations"}, cfg.LabelFilters...),
+		Importance: "high",
+	}
+
+	digest := email.EmailMessage{
+		ID:         "msg-digest",
+		Subject:    "Daily automation digest",
+		Sender:     "automation-bot@example.com",
+		ReceivedAt: now.Add(-6 * time.Hour),
+		Snippet:    fmt.Sprintf("%d workflows executed, 12 emails triaged automatically.", 4+cfg.SyncWindowHours/24),
+		Labels:     append([]string{"Automation"}, cfg.LabelFilters...),
+		Importance: "normal",
+	}
+
+	return []email.EmailMessage{summary, escalated, digest}, nil
+}

--- a/internal/email/clock.go
+++ b/internal/email/clock.go
@@ -1,0 +1,16 @@
+package email
+
+import "time"
+
+// SystemClock uses the Go runtime time source.
+type SystemClock struct{}
+
+// NewSystemClock constructs a SystemClock.
+func NewSystemClock() Clock {
+	return SystemClock{}
+}
+
+// Now returns the current UTC time.
+func (SystemClock) Now() time.Time {
+	return time.Now().UTC()
+}

--- a/internal/email/hash.go
+++ b/internal/email/hash.go
@@ -1,0 +1,20 @@
+package email
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+)
+
+// SHA256Hasher hashes secrets using SHA256.
+type SHA256Hasher struct{}
+
+// NewSHA256Hasher creates a SHA256-backed hasher implementation.
+func NewSHA256Hasher() SecretHasher {
+	return SHA256Hasher{}
+}
+
+// Hash implements the SecretHasher interface.
+func (SHA256Hasher) Hash(secret string) (string, error) {
+	sum := sha256.Sum256([]byte(secret))
+	return hex.EncodeToString(sum[:]), nil
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -14,6 +14,9 @@ import (
 	"github.com/labstack/echo/v4/middleware"
 
 	"github.com/example/iboz/internal/api"
+	"github.com/example/iboz/internal/email"
+	"github.com/example/iboz/internal/email/adapter/memory"
+	"github.com/example/iboz/internal/email/adapter/synthetic"
 )
 
 //go:embed all:static
@@ -36,7 +39,10 @@ func New() *Server {
 	e.Use(middleware.Logger())
 	e.Use(middleware.Recover())
 
-	api.Register(e.Group("/api"))
+	emailRepo := memory.NewRepository()
+	emailService := email.NewService(emailRepo, email.NewSHA256Hasher(), synthetic.NewGenerator(), email.NewSystemClock())
+
+	api.Register(e.Group("/api"), emailService)
 
 	subFS, err := fs.Sub(embeddedStatic, "static")
 	if err != nil {


### PR DESCRIPTION
## Summary
- restructure the email service behind explicit ports, context-aware methods, and injected collaborators to better follow hexagonal architecture
- add in-memory and synthetic adapters plus clock and hashing utilities that satisfy the new domain interfaces
- wire the email service through API handlers and server composition and update tests to exercise the new dependency flow

## Testing
- go test ./...
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d0d5c973a48322aa23cb98dc82305b